### PR TITLE
Add Canada data/ML jobs resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Note: This list is not complete, and there are many more companies out there. This list just represents the company names and positions that I was aware of during my internship search, in no particular order. I was based in the US during this internship search. The preference or minimum qualifications are often updated by the teams depending on the then requirement. Considering the ever-changing market and hiring policies, always check the respective career websites to know about the current open positions and eligibility.
 
+Canada-specific companion resource: [Hanzilla Jobs - Data / ML jobs in Canada](https://jobs.hanzilla.co/categories/data-ml/) lists daily-updated Canadian student and recent-grad data, analytics, AI/ML, internship, co-op, new-grad, junior, and entry-level roles.
+
 Last updated: 13th February, 2023
 ---
 


### PR DESCRIPTION
## Summary

Adds a small Canada-specific companion resource for students using this ML/data-science internship list.

Hanzilla Jobs is a free daily-updated Canadian student/recent-grad jobs board. The linked Data / ML page focuses on Canadian data, analytics, AI/ML, internship, co-op, new-grad, junior, and entry-level roles.

## Why here

The README notes that the original list was compiled from a US-based internship search and that students should check current career sites because openings change. This adds one Canada-specific live source as a complement rather than replacing the existing company list.

## Link checked

- https://jobs.hanzilla.co/categories/data-ml/ returns 200 and is indexable.
